### PR TITLE
Fixes prefix_ and suffix_ padding equation

### DIFF
--- a/960/_grid.styl
+++ b/960/_grid.styl
@@ -55,10 +55,10 @@ grid_(n, c = var_grid_columns, g = var_grid_gutter)
 	grid_content()
 	
 prefix_(n, c = var_grid_columns, g = var_grid_gutter)
-	padding-left ((var_grid_width / c * n) + (g / 2))
+	padding-left (var_grid_width / c * n)
 
 suffix_(n, c = var_grid_columns, g = var_grid_gutter)
-	padding-right ((var_grid_width / c * n) + (g / 2))
+	padding-right (var_grid_width / c * n)
 	
 push_(n, c = var_grid_columns)
 	position relative


### PR DESCRIPTION
The old equation included the gutter twice. This new equation fixes this.
